### PR TITLE
Updated XF options regex for new gfont argument

### DIFF
--- a/src/addons/RpNation/_data/bb_codes.xml
+++ b/src/addons/RpNation/_data/bb_codes.xml
@@ -52,7 +52,7 @@
   </bb_code>
 
   <!-- Google Fonts -->
-    <bb_code bb_code_id="font" bb_code_mode="callback" has_option="yes" callback_class="RpNation\BbCode\Font" callback_method="renderFontTag" option_regex="/^[a-z0-9 \-]+$/i" trim_lines_after="0" plain_children="0" disable_smilies="0" disable_nl2br="0" disable_autolink="0" allow_empty="0" allow_signature="1" active="1">
+    <bb_code bb_code_id="font" bb_code_mode="callback" has_option="yes" callback_class="RpNation\BbCode\Font" callback_method="renderFontTag" option_regex="/^[a-z0-9 \-\"=]+$/i" trim_lines_after="0" plain_children="0" disable_smilies="0" disable_nl2br="0" disable_autolink="0" allow_empty="0" allow_signature="1" active="1">
     <replace_html><![CDATA[]]></replace_html>
     <replace_html_email><![CDATA[]]></replace_html_email>
     <replace_text><![CDATA[]]></replace_text>


### PR DESCRIPTION
Added in quotation mark and equal sign into the regex. We could just get rid of it completely, as I can't imagine an edge case where we need it